### PR TITLE
add local cogcomp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,9 @@ simple rule based named entity recognition
     + [NER wrappers](#ner-wrappers)
       - [NLTK](#nltk)
       - [Spacy](#spacy)
+      - [Cogcomp](#cogcomp)
     + [Remote annotators](#remote-annotators)
       - [Spotlight](#spotlight)
-      - [Cogcomp](#cogcomp)
       - [Online Demos](#online-demos)
   * [Similar Projects](#similar-projects)
   
@@ -335,6 +335,60 @@ You need an extra install step in order to use this
 
 In addition you will need to download the spacy models
 
+#### Cogcomp
+
+wrapper for [cogcomp-nlpy](https://github.com/CogComp/cogcomp-nlpy), needs manual install
+
+You can run the local pipeline
+
+```python
+from simple_NER.annotators.cogcomp_ner import CogcompNER
+
+ner = CogcompNER() # use ontonotes model
+# ner = CogcompNER(ontonotes=False)  # use connl model
+
+text = """"Helicopters will patrol the temporary no-fly zone around 
+New Jersey's MetLife Stadium Sunday, with F-16s based in Atlantic City 
+ready to be scrambled if an unauthorized aircraft does enter the 
+restricted airspace"""
+
+for r in ner.extract_entities(text):
+    print(r.value, r.entity_type)
+    """
+    New Jersey 's GPE
+    MetLife Stadium ORG
+    Sunday DATE
+    Atlantic City GPE
+    """
+
+```
+
+or the remote pipeline
+
+```python
+from simple_NER.annotators.remote.cogcomp import CogcompNER
+
+# you may use you own server, demo is limited to 100 queries/day
+host = None
+ner = CogcompNER(host) # use ontonotes model
+# ner = CogcompNER(host, ontonotes=False)  # use connl model
+
+text = """"Helicopters will patrol the temporary no-fly zone around 
+New Jersey's MetLife Stadium Sunday, with F-16s based in Atlantic City 
+ready to be scrambled if an unauthorized aircraft does enter the 
+restricted airspace"""
+
+for r in ner.extract_entities(text):
+    print(r.value, r.entity_type)
+    """
+    New Jersey 's GPE
+    MetLife Stadium ORG
+    Sunday DATE
+    Atlantic City GPE
+    """
+```
+
+
 ```python
 from simple_NER.annotators.spacy_ner import SpacyNER
 ner = SpacyNER()
@@ -372,33 +426,6 @@ for r in ner.extract_entities("elon musk works in spaceX"):
     spaceX Organisation http://dbpedia.org/resource/SpaceX
     spaceX Company http://dbpedia.org/resource/SpaceX
     spaceX Agent http://dbpedia.org/resource/SpaceX
-    """
-```
-
-#### Cogcomp
-
-wrapper for [cogcomp-nlpy](https://github.com/CogComp/cogcomp-nlpy), needs manual install
-
-```python
-from simple_NER.annotators.remote.cogcomp import CogcompNER
-
-# you may use you own server, demo is limited to 100 queries/day
-host = None
-ner = CogcompNER(host) # use ontonotes model
-# ner = CogcompNER(host, ontonotes=False)  # use connl model
-
-text = """"Helicopters will patrol the temporary no-fly zone around 
-New Jersey's MetLife Stadium Sunday, with F-16s based in Atlantic City 
-ready to be scrambled if an unauthorized aircraft does enter the 
-restricted airspace"""
-
-for r in ner.extract_entities(text):
-    print(r.value, r.entity_type)
-    """
-    New Jersey 's GPE
-    MetLife Stadium ORG
-    Sunday DATE
-    Atlantic City GPE
     """
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files('simple_NER')
 
 setup(
     name='simple_NER',
-    version='0.1.11',
+    version='0.1.12',
     packages=['simple_NER', 'simple_NER.rules', 'simple_NER.annotators',
               'simple_NER.annotators.utils',
               'simple_NER.annotators.utils.keywords'],

--- a/simple_NER/annotators/cogcomp_ner.py
+++ b/simple_NER/annotators/cogcomp_ner.py
@@ -1,0 +1,61 @@
+from simple_NER.annotators import NERWrapper
+from simple_NER import Entity
+
+try:
+    from ccg_nlpy import local_pipeline
+except ImportError:
+    print("you need to install cogcomp nlpy")
+    print("pip install cython")
+    print("sudo apt-get install openjdk-8-jdk")
+    print("pip install ccg_nlpy")
+    print("")
+    print("install maven: https://maven.apache.org/install.html")
+    print("and download the models: python -m ccg_nlpy download")
+    raise
+
+
+class CogcompNER(NERWrapper):
+    def __init__(self, ontonotes=True):
+        super().__init__()
+        self.connl = not ontonotes
+        self.ontonotes = ontonotes
+        self.pipeline = local_pipeline.LocalPipeline()
+        self.add_detector(self.annotate)
+
+    def annotate(self, text, pretokenized=False):
+        doc = self.pipeline.doc(text, pretokenized=pretokenized)
+        if doc is not None:
+            cons_list = []
+            if self.connl:
+                ents = doc.get_ner_conll
+                if ents.cons_list:
+                    cons_list += ents.cons_list
+            elif self.ontonotes:
+                ents = doc.get_ner_ontonotes
+                if ents.cons_list:
+                    cons_list += ents.cons_list
+            for e in cons_list:
+                yield Entity(e["tokens"],
+                             e["label"],
+                             source_text=text,
+                             data=e)
+
+
+if __name__ == "__main__":
+
+    ner = CogcompNER()  # use ontonotes model
+    # ner = CogcompNER(ontonotes=False)  # use connl model
+
+    text = """"Helicopters will patrol the temporary no-fly zone around 
+    New Jersey's MetLife Stadium Sunday, with F-16s based in Atlantic City 
+    ready to be scrambled if an unauthorized aircraft does enter the 
+    restricted airspace"""
+
+    for r in ner.extract_entities(text):
+        print(r.value, r.entity_type)
+        """
+        New Jersey 's GPE
+        MetLife Stadium ORG
+        Sunday DATE
+        Atlantic City GPE
+        """


### PR DESCRIPTION
support for local cogcomp ner (previously only remote pipeline)

```python
from simple_NER.annotators.cogcomp_ner import CogcompNER

ner = CogcompNER() # use ontonotes model
# ner = CogcompNER(ontonotes=False)  # use connl model

text = """"Helicopters will patrol the temporary no-fly zone around 
New Jersey's MetLife Stadium Sunday, with F-16s based in Atlantic City 
ready to be scrambled if an unauthorized aircraft does enter the 
restricted airspace"""

for r in ner.extract_entities(text):
    print(r.value, r.entity_type)
    """
    New Jersey 's GPE
    MetLife Stadium ORG
    Sunday DATE
    Atlantic City GPE
    """

```